### PR TITLE
Fix Uncaught SyntaxError

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,6 @@
     <head>
         <title>Xeact</title>
         <link rel="stylesheet" href="./gruvbox.css">
-        <script src="./xeact.js"></script>
         <script src="./index.js" type="module"></script>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </head>


### PR DESCRIPTION
When visiting [the project website](https://xena.greedo.xeserv.us/Xeact/) there is the following error message in the console:
```
Uncaught SyntaxError: export declarations may only appear at top level of a module
```
and according to [this StackOverflow answer](https://stackoverflow.com/questions/63630025/getting-export-declarations-may-only-appear-at-top-level-of-a-module-in-javascri/63630396#63630396) as well as my own testing, this one-line change should be enough to fix it