### PR TITLE
Add JSX support

### DIFF
--- a/jsx-runtime.js
+++ b/jsx-runtime.js
@@ -1,0 +1,14 @@
+import { h } from './xeact';
+
+/**
+ * Create a DOM element, assign the properties of `data` to it, and append all `data.children`.
+ *
+ * @type{function(string, Object=): HTMLElement}
+ */
+export const jsx = (tag, data) => {
+  let children = data.children;
+  delete data.children;
+  const result = h(tag, data, children);
+  result.classList.value = result.class;
+  return result;
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"lol you think there's tests for this kind of a shitpost\"",
     "serve": "cd site && nix-shell -p python3 --run 'python3 -m http.server'",
-    "gentypes": "nix-shell -p nodePackages.typescript --run 'tsc xeact.js --declaration --allowJs --emitDeclarationOnly --outDir types'",
+    "gentypes": "nix-shell -p nodePackages.typescript --run 'tsc xeact.js jsx-runtime.js --declaration --allowJs --emitDeclarationOnly --outDir types'",
     "minify": "nix-shell -p nodePackages.uglify-js --run 'uglifyjs xeact.js -c -m > xeact.min.js'"
   },
   "repository": {

--- a/types/jsx-runtime.d.ts
+++ b/types/jsx-runtime.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Create a DOM element, assign the properties of `data` to it, and append all `data.children`.
+ *
+ * @type{function(string, Object=): HTMLElement}
+ */
+export const jsx: (arg0: string, arg1: any | undefined) => HTMLElement;


### PR DESCRIPTION
Being a React parody, this should _definitely_ support JSX
This allows using the `h` function as a jsx factory when setting
```json
"compilerOptions": {
  "jsx": "react-jsx",
  "jsxImportSource": "@xeserv/xeact",
  ...
}
```
in tsconfig.json/jsconfig.json

(yes, this does actually work and the output I get is _waaaay_ shorter than with preact)